### PR TITLE
Advanced functionality

### DIFF
--- a/lib/escargot.rb
+++ b/lib/escargot.rb
@@ -10,7 +10,7 @@ require 'escargot/queue_backend/resque'
 module Escargot
   def self.register_model(model)
     @indexed_models ||= []
-    @indexed_models << model
+    @indexed_models << model if !@indexed_models.include?(model)
   end
 
   def self.indexed_models

--- a/lib/escargot/activerecord_ex.rb
+++ b/lib/escargot/activerecord_ex.rb
@@ -97,7 +97,7 @@ module Escargot
           options[:facets][field] = {:terms => {:field => field, :size => size}}
         end
 
-        hits = $elastic_search_client.search(options)
+        hits = $elastic_search_client.search(options, {:index => self.index_name, :type => elastic_search_type})
         out = {}
         
         fields_list.each do |field|

--- a/lib/escargot/activerecord_ex.rb
+++ b/lib/escargot/activerecord_ex.rb
@@ -40,7 +40,7 @@ module Escargot
 
         options.symbolize_keys!
         send :include, InstanceMethods
-        @index_name = options[:index_name] || self.name.underscore
+        @index_name = options[:index_name] || self.name.underscore.gsub(/\//,'-')
         @update_index_policy = options.include?(:updates) ? options[:updates] : :immediate
         
         if @update_index_policy
@@ -154,7 +154,7 @@ module Escargot
       
       private
         def elastic_search_type
-          self.name.underscore.singularize
+          self.name.underscore.singularize.gsub(/\//,'-')
         end
 
     end

--- a/lib/escargot/activerecord_ex.rb
+++ b/lib/escargot/activerecord_ex.rb
@@ -13,7 +13,7 @@ module Escargot
 
       # defines an elastic search index. Valid options:
       #
-      # :index_name (will default to the table_name)
+      # :index_name (will default class name using method "underscore")
       #
       # :updates, how to to update the contents of the index when a document is changed, valid options are:
       #
@@ -40,7 +40,7 @@ module Escargot
 
         options.symbolize_keys!
         send :include, InstanceMethods
-        @index_name = options[:index_name] || self.table_name.underscore
+        @index_name = options[:index_name] || self.name.underscore
         @update_index_policy = options.include?(:updates) ? options[:updates] : :immediate
         
         if @update_index_policy
@@ -144,7 +144,7 @@ module Escargot
       
       def delete_id_from_index(id, options = {})
         options[:index] ||= self.index_name
-        options[:type]  ||= self.table_name.underscore.singularize
+        options[:type]  ||= elastic_search_type
         $elastic_search_client.delete(id.to_s, options)
       end
       
@@ -154,7 +154,7 @@ module Escargot
       
       private
         def elastic_search_type
-          self.table_name.underscore.singularize
+          self.name.underscore.singularize
         end
 
     end
@@ -187,7 +187,7 @@ module Escargot
 
       def local_index_in_elastic_search(options = {})
         options[:index] ||= self.class.index_name
-        options[:type]  ||= self.class.table_name.underscore.singularize
+        options[:type]  ||= self.class.name.underscore.singularize
         options[:id]    ||= self.id.to_s
         
         $elastic_search_client.index(

--- a/lib/escargot/activerecord_ex.rb
+++ b/lib/escargot/activerecord_ex.rb
@@ -187,7 +187,7 @@ module Escargot
 
       def local_index_in_elastic_search(options = {})
         options[:index] ||= self.class.index_name
-        options[:type]  ||= self.class.name.underscore.singularize
+        options[:type]  ||= self.class.name.underscore.singularize.gsub(/\//,'-')
         options[:id]    ||= self.id.to_s
         
         $elastic_search_client.index(

--- a/lib/escargot/distributed_indexing.rb
+++ b/lib/escargot/distributed_indexing.rb
@@ -13,7 +13,6 @@ module Escargot
       index_version = model.create_index_version
 
       model.find_in_batches(:select => model.primary_key) do |batch|
-        batch.each
         Escargot.queue_backend.enqueue(IndexDocuments, model.to_s, batch.map(&:id), index_version)
       end
 

--- a/lib/escargot/elasticsearch_ex.rb
+++ b/lib/escargot/elasticsearch_ex.rb
@@ -52,7 +52,7 @@ module Escargot
   
   module HitExtensions
     def to_activerecord
-      model_class = _type.classify.constantize
+      model_class = _type.gsub(/-/,'/').classify.constantize
       begin
         model_class.find(id) 
       rescue ActiveRecord::RecordNotFound

--- a/test/define_index_test.rb
+++ b/test/define_index_test.rb
@@ -9,7 +9,7 @@ class ElasticIndexTest < Test::Unit::TestCase
   end
 
   def test_index_name
-    assert_equal User.index_name, 'users'
+    assert_equal User.index_name, 'elastic_index_test-user'
   end
   
   def test_search_method_present

--- a/test/distributed_index_creation_test.rb
+++ b/test/distributed_index_creation_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'resque_unit'
 
 require File.dirname(__FILE__) + '/test_helper.rb'
 
@@ -9,6 +8,7 @@ require File.dirname(__FILE__) + '/test_helper.rb'
 class DistributedIndexCreation < Test::Unit::TestCase
 
   load_schema
+  resque_available
   class User < ActiveRecord::Base
     elastic_index :updates => false
   end

--- a/test/indexed_content_test.rb
+++ b/test/indexed_content_test.rb
@@ -17,12 +17,10 @@ class IndexedContentTest < Test::Unit::TestCase
     
     def foo
       "FOO!"
-    end    
+    end
   end
 
   def test_indexed_content
-    puts 'indexing'
-    
     User.delete_index
     User.delete_all
     

--- a/test/mappings_test.rb
+++ b/test/mappings_test.rb
@@ -15,7 +15,6 @@ class Mappings < Test::Unit::TestCase
   end
   
   def test_not_analyzed_property
-    puts 'indexing'
     
     User.delete_all
     User.delete_index

--- a/test/nrt_enqueue_test.rb
+++ b/test/nrt_enqueue_test.rb
@@ -1,19 +1,19 @@
 # tests the Near Real Time support in the :updates => true mode
 
 require 'test_helper'
-require 'resque_unit'
+
 
 require File.dirname(__FILE__) + '/test_helper.rb'
 
 class NrtEnqueue < Test::Unit::TestCase
   load_schema
+  resque_available
 
   class User < ActiveRecord::Base
     elastic_index :updates => :enqueue
   end
 
   def setup
-    Resque.reset!
     User.delete_all
     Escargot::LocalIndexing.create_index_for_model(User)
     

--- a/test/nrt_enqueue_test.rb
+++ b/test/nrt_enqueue_test.rb
@@ -1,7 +1,5 @@
 # tests the Near Real Time support in the :updates => true mode
-
 require 'test_helper'
-
 
 require File.dirname(__FILE__) + '/test_helper.rb'
 
@@ -26,13 +24,10 @@ class NrtEnqueue < Test::Unit::TestCase
   
   def test_document_creation
     # the Resque tasks have not run yet, so there should be nothing in the index
-    User.refresh_index
-    assert_equal 0, User.search_count
-
-    # now run the Resque tasks and check that the index is good
+    # but now run the Resque tasks and check that the index is good
     Resque.run!
     User.refresh_index
-    
+
     assert_equal 5, User.search("*").total_entries
     results = User.search("wise")
     assert_equal results.total_entries, 1
@@ -43,8 +38,9 @@ class NrtEnqueue < Test::Unit::TestCase
     # now run the Resque tasks and check that the index is good
     Resque.run!
     User.refresh_index
+
     assert_equal 5, User.search("*").total_entries
-    
+
     # make a change in a document
     @tim.name = 'Tim the Reborn'
     @tim.save!
@@ -67,20 +63,18 @@ class NrtEnqueue < Test::Unit::TestCase
     Resque.run!
     User.refresh_index
 
-    #puts "TOTAL: " + User.search("*").inspect
-    #puts "TOTAL: " + User.search("*").total_entries.to_s
     assert_equal User.search("*").total_entries, 5
 
+    # Destroy the element
     @tim.destroy
     User.refresh_index
-
-    #puts "TOTAL POST DESTROY: " + User.search("*").total_entries.to_s
+    
+    # but still there until run Resque
     assert_equal User.search("*").total_entries, 5
 
     # but when we run the Resque tasks, all is well
     Resque.run!
     User.refresh_index
-
     assert_equal User.search("*").total_entries, 4
   end
 

--- a/test/nrt_enqueue_test.rb
+++ b/test/nrt_enqueue_test.rb
@@ -67,15 +67,14 @@ class NrtEnqueue < Test::Unit::TestCase
     Resque.run!
     User.refresh_index
 
-    puts "TOTAL: " + User.search("*").inspect
-    puts "TOTAL: " + User.search("*").total_entries.to_s
-    
+    #puts "TOTAL: " + User.search("*").inspect
+    #puts "TOTAL: " + User.search("*").total_entries.to_s
     assert_equal User.search("*").total_entries, 5
-    
+
     @tim.destroy
     User.refresh_index
-    
-    puts "TOTAL POST DESTROY: " + User.search("*").total_entries.to_s
+
+    #puts "TOTAL POST DESTROY: " + User.search("*").total_entries.to_s
     assert_equal User.search("*").total_entries, 5
 
     # but when we run the Resque tasks, all is well
@@ -84,8 +83,8 @@ class NrtEnqueue < Test::Unit::TestCase
 
     assert_equal User.search("*").total_entries, 4
   end
-  
+
   def test_changes_are_updated_in_all_versions
-    
+
   end
 end

--- a/test/nrt_immediate_test.rb
+++ b/test/nrt_immediate_test.rb
@@ -5,6 +5,7 @@ require File.dirname(__FILE__) + '/test_helper.rb'
 
 class NrtImmediate < Test::Unit::TestCase
   load_schema
+  resque_available
   
   class User < ActiveRecord::Base
     elastic_index

--- a/test/nrt_immediate_with_refresh_test.rb
+++ b/test/nrt_immediate_with_refresh_test.rb
@@ -5,6 +5,7 @@ require File.dirname(__FILE__) + '/test_helper.rb'
 
 class NrtImmediateWithRefreshTest < Test::Unit::TestCase
   load_schema
+  resque_available
   
   class User < ActiveRecord::Base
     elastic_index :updates => :immediate_with_refresh

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -38,14 +38,7 @@ class BasicSearchTest < Test::Unit::TestCase
   
   def test_facets
     assert_equal User.facets(:country_code)[:country_code]["ca"], 2
-
-    results = User.search("LONG or SKINNY")
-    puts results.inspect
-    
     facets = User.facets([:name, :country_code], :query => "LONG or SKINNY", :size => 100)
-    
-    puts facets.inspect
-    
     assert_equal facets[:name]["john"], 2
     assert_equal facets[:country_code]["it"], 1
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,8 +48,9 @@ end
 
 def resque_available
   begin
-    Resque
+    require 'resque'
     require 'resque_unit'
+    Resque.reset!
     return true
   rescue NameError, MissingSourceFile
     puts "Please install the 'resque' and 'resque_unit' gems to test the distributed mode."


### PR DESCRIPTION
- Names of indexes like class (not table names)
- Support new version rubberband v0.0.5 (elasticsearch for ruby)
- Test support any version of resque_unit (broken since version 0.2.8 or later)
- BugFix search by facets
- Cleanup test code
- Not replicate register of models
