### PR TITLE
Bugfix: Make search_count work with Query DSL

### DIFF
--- a/lib/escargot/activerecord_ex.rb
+++ b/lib/escargot/activerecord_ex.rb
@@ -76,9 +76,6 @@ module Escargot
 
       # counts the number of results for this query.
       def search_count(query = "*", options = {})
-        if query.kind_of?(Hash)
-          query = {:query => query}
-        end
         $elastic_search_client.count(query, options.merge({:index => self.index_name, :type => elastic_search_type}))
       end
 

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -36,6 +36,12 @@ class BasicSearchTest < Test::Unit::TestCase
     assert_equal User.search_count("peter"), 2
   end
   
+  def test_search_count_with_query
+    results = User.search(:term => {:name => "John the Long"})
+    assert_equal results.total_entries, 1
+    assert_equal User.search_count(:term => {:name => "John the Long"}), 1
+  end
+  
   def test_facets
     assert_equal User.facets(:country_code)[:country_code]["ca"], 2
     facets = User.facets([:name, :country_code], :query => "LONG or SKINNY", :size => 100)


### PR DESCRIPTION
Rubberband / ElasticSearch doesn't expect Query DSL's to be wrapped in a :query when using search_count.

This resolves the issue.
