### PR TITLE
Treat query_dsl as part of options rather than query

### DIFF
--- a/lib/escargot.rb
+++ b/lib/escargot.rb
@@ -42,7 +42,7 @@ module Escargot
     end
     
     if query.kind_of?(Hash)
-      query_dsl = query.delete(:query_dsl)
+      query_dsl = options.delete(:query_dsl)
       query = {:query => query} if (query_dsl.nil? || query_dsl)
     end
     $elastic_search_client.search(query, options)

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -56,7 +56,14 @@ class BasicSearchTest < Test::Unit::TestCase
     results = User.search({:sort =>[{ :country_code => {:reverse => true }}] , :query => {:term => {:name => "john"}}, :track_scores =>true}, :query_dsl => false)
     assert_equal results.first.name, 'John the Skinny Too'
   end
-  
+
+  def test_search_without_query_dsl_with_pagination
+    results = User.search({:sort =>[{:country_code => {:reverse => true}}], :query => {:match_all => true}}, :query_dsl => false, :per_page => 5, :page => 1)
+    assert_equal results.count, 5
+
+    results = User.search({:sort =>[{:country_code => {:reverse => true}}], :query => {:match_all => true}}, :query_dsl => false, :per_page => 5, :page => 2)
+    assert_equal results.count, 1
+  end
 
   def test_facets
     assert_equal User.facets(:country_code)[:country_code]["ca"], 2

--- a/test/search_test.rb
+++ b/test/search_test.rb
@@ -53,7 +53,7 @@ class BasicSearchTest < Test::Unit::TestCase
     # putting in the query Hash the option ":query_dsl => false", of course remember to put the term ":query => {your query}"
     # to work correctly
 
-    results = User.search(:sort =>[{ :country_code => {:reverse => true }}] , :query => {:term => {:name => "john"}}, :query_dsl => false,:track_scores =>true)
+    results = User.search({:sort =>[{ :country_code => {:reverse => true }}] , :query => {:term => {:name => "john"}}, :track_scores =>true}, :query_dsl => false)
     assert_equal results.first.name, 'John the Skinny Too'
   end
   


### PR DESCRIPTION
Queries written with `query_dsl => false` should also use options. The current implementation doesn't allow them. That is, when I do 

<pre>
User.search :sort => [{:weight => "desc"}], 
                   :query => {:match_all => {}},
                   :query_dsl => false,
                   :per_page => 10,
                   :page => 1
</pre>


even though per_page and page are treated as part of query and are passed to ES resulting in a failing query, however they are options passed to escargot and should not be passed down to elastic search.

PS: there is a failing test, which was failing before I did my changes. I think it should pass, but I am not sure why it is failing.

<pre>
1) Failure:
test_not_analyzed_property(Mappings) [./test/mappings_test.rb:30]:
<1> expected but was
<0>.
</pre>
